### PR TITLE
feat: Create Book Flow UI + Validation (#3)

### DIFF
--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -1,38 +1,41 @@
 import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, Sparkles } from "lucide-react";
+import { CreateBookForm } from "@/components/create/CreateBookForm";
+import { Toaster } from "@/components/ui/sonner";
 
 export default function CreatePage() {
   return (
-    <main className="min-h-screen flex flex-col items-center justify-center px-4 py-16">
-      {/* Background gradient */}
-      <div className="absolute inset-0 gradient-warm -z-10" />
+    <>
+      <Toaster position="top-center" />
+      <main className="min-h-screen">
+        {/* Background gradient */}
+        <div className="fixed inset-0 gradient-warm -z-10" />
 
-      <div className="text-center max-w-md">
-        {/* Icon */}
-        <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-primary/10 border border-primary/20 mb-8 animate-float">
-          <Sparkles className="w-10 h-10 text-primary" />
+        {/* Header */}
+        <header className="sticky top-0 z-20 bg-background/80 backdrop-blur-sm border-b">
+          <div className="max-w-2xl mx-auto px-4 py-4 flex items-center gap-4">
+            <Button asChild variant="ghost" size="icon" className="shrink-0">
+              <Link href="/" aria-label="Back to home">
+                <ArrowLeft className="w-5 h-5" />
+              </Link>
+            </Button>
+            <div>
+              <h1 className="font-[family-name:var(--font-fraunces)] text-xl font-semibold">
+                Create Your Storybook
+              </h1>
+              <p className="text-sm text-muted-foreground">
+                Tell us about your child
+              </p>
+            </div>
+          </div>
+        </header>
+
+        {/* Form */}
+        <div className="max-w-2xl mx-auto px-4 py-8 pb-24">
+          <CreateBookForm />
         </div>
-
-        {/* Headline */}
-        <h1 className="font-[family-name:var(--font-fraunces)] text-3xl sm:text-4xl font-semibold mb-4">
-          Coming Soon
-        </h1>
-
-        {/* Description */}
-        <p className="text-muted-foreground text-lg mb-8 leading-relaxed">
-          We&apos;re putting the finishing touches on our storybook creator.
-          Check back soon to create your child&apos;s personalized adventure!
-        </p>
-
-        {/* Back button */}
-        <Button asChild variant="outline" size="lg" className="rounded-full">
-          <Link href="/">
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            Back to Home
-          </Link>
-        </Button>
-      </div>
-    </main>
+      </main>
+    </>
   );
 }

--- a/app/create/preview/page.tsx
+++ b/app/create/preview/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft, Sparkles } from "lucide-react";
+
+export default function PreviewPage() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center px-4 py-16">
+      {/* Background gradient */}
+      <div className="absolute inset-0 gradient-warm -z-10" />
+
+      <div className="text-center max-w-md">
+        {/* Icon */}
+        <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-primary/10 border border-primary/20 mb-8 animate-float">
+          <Sparkles className="w-10 h-10 text-primary" />
+        </div>
+
+        {/* Headline */}
+        <h1 className="font-[family-name:var(--font-fraunces)] text-3xl sm:text-4xl font-semibold mb-4">
+          Preview Coming Soon
+        </h1>
+
+        {/* Description */}
+        <p className="text-muted-foreground text-lg mb-8 leading-relaxed">
+          Your storybook details have been saved! The preview generation
+          feature is coming in the next update.
+        </p>
+
+        {/* Back button */}
+        <Button asChild variant="outline" size="lg" className="rounded-full">
+          <Link href="/create">
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            Back to Create
+          </Link>
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [0.2.0] - 2026-01-06
+
+### Added - Create Book Flow (Step 1) — `/create` Page UI + Validation
+
+**Issue:** #3 - Build /create Page UI + Validation (No Backend)
+
+#### Features
+- Complete book creation form with client-side validation
+- Child details section (name, age band, interests multi-select)
+- Story preferences section (tone radio cards, optional lesson textarea)
+- Photo upload with drag & drop support, preview, and replace functionality
+- Form persistence via sessionStorage (auto-save on change)
+- Sticky submit button on mobile for better UX
+- Form state preserved across page refreshes (except photo)
+
+#### Validation Rules (Zod)
+- Child name: 2-32 chars, letters/spaces/hyphens/apostrophes only
+- Age band: required selection (3-4, 5-6, 7-9)
+- Interests: 1-3 selections from presets or custom entries
+- Tone: required selection (gentle, funny, brave)
+- Lesson: optional, max 140 characters
+- Photo: required, JPG/PNG/WebP only, max 8MB
+
+#### Components Created
+- `components/create/CreateBookForm.tsx` - Main form orchestrating all fields
+- `components/create/InterestsInput.tsx` - Multi-select tag input with custom entry
+- `components/create/PhotoDropzone.tsx` - Drag & drop photo upload with preview
+
+#### Library Files Created
+- `lib/constants/storyOptions.ts` - Centralized constants (age bands, tones, interests, photo config)
+- `lib/validators/createBook.ts` - Zod schema + TypeScript types
+
+#### Pages
+- `app/create/page.tsx` - Fully functional create book form
+- `app/create/preview/page.tsx` - Placeholder for next step
+
 ## [0.1.0] - 2026-01-06
 
 ### Added - Landing Page UI (v1)

--- a/components/create/CreateBookForm.tsx
+++ b/components/create/CreateBookForm.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Sparkles, User, BookOpen } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+
+import { PhotoDropzone } from "./PhotoDropzone";
+import { InterestsInput } from "./InterestsInput";
+import {
+  createBookSchema,
+  type CreateBookFormData,
+} from "@/lib/validators/createBook";
+import { AGE_BANDS, TONES } from "@/lib/constants/storyOptions";
+
+const STORAGE_KEY = "createBookFormData";
+
+export function CreateBookForm() {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  const form = useForm<CreateBookFormData>({
+    resolver: zodResolver(createBookSchema),
+    defaultValues: {
+      childName: "",
+      ageBand: undefined,
+      interests: [],
+      tone: undefined,
+      lesson: "",
+      photo: undefined,
+    },
+    mode: "onBlur",
+  });
+
+  // Load saved form data on mount (except photo)
+  React.useEffect(() => {
+    try {
+      const saved = sessionStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        const data = JSON.parse(saved);
+        // Reset form with saved data (photo excluded)
+        form.reset({
+          childName: data.childName || "",
+          ageBand: data.ageBand,
+          interests: data.interests || [],
+          tone: data.tone,
+          lesson: data.lesson || "",
+          photo: undefined,
+        });
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }, [form]);
+
+  // Save form data on change (debounced, excludes photo)
+  React.useEffect(() => {
+    const subscription = form.watch((data) => {
+      try {
+        const { photo, ...rest } = data;
+        sessionStorage.setItem(STORAGE_KEY, JSON.stringify(rest));
+      } catch {
+        // Ignore storage errors
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, [form]);
+
+  const onSubmit = async (data: CreateBookFormData) => {
+    setIsSubmitting(true);
+
+    try {
+      // Convert photo to dataURL for storage persistence
+      const reader = new FileReader();
+      reader.onload = () => {
+        const formDataWithPhoto = {
+          childName: data.childName,
+          ageBand: data.ageBand,
+          interests: data.interests,
+          tone: data.tone,
+          lesson: data.lesson,
+          photoDataUrl: reader.result as string,
+          photoName: data.photo.name,
+          photoType: data.photo.type,
+        };
+        sessionStorage.setItem(
+          "createBookFormComplete",
+          JSON.stringify(formDataWithPhoto)
+        );
+        router.push("/create/preview");
+      };
+      reader.onerror = () => {
+        toast.error("Failed to process photo. Please try again.");
+        setIsSubmitting(false);
+      };
+      reader.readAsDataURL(data.photo);
+    } catch {
+      toast.error("Something went wrong. Please try again.");
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleSubmitError = () => {
+    toast.error("Please fix the errors above before continuing.");
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit, handleSubmitError)}
+        className="space-y-8"
+      >
+        {/* Section 1: Child Details */}
+        <Card className="paper-texture">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 font-[family-name:var(--font-fraunces)]">
+              <User className="w-5 h-5 text-primary" />
+              Child Details
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {/* Child Name */}
+            <FormField
+              control={form.control}
+              name="childName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Child&apos;s Name</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="e.g., Emma"
+                      autoComplete="off"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    This is how your child will appear in the story.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Age Band */}
+            <FormField
+              control={form.control}
+              name="ageBand"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Age Range</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Select age range" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {AGE_BANDS.map((band) => (
+                        <SelectItem key={band.value} value={band.value}>
+                          {band.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>
+                    We&apos;ll adjust vocabulary and themes for this age group.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Interests */}
+            <FormField
+              control={form.control}
+              name="interests"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Interests (1-3)</FormLabel>
+                  <FormControl>
+                    <InterestsInput
+                      value={field.value}
+                      onChange={field.onChange}
+                      maxSelections={3}
+                      error={!!form.formState.errors.interests}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    These will be woven into your child&apos;s adventure.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+        </Card>
+
+        {/* Section 2: Story Preferences */}
+        <Card className="paper-texture">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 font-[family-name:var(--font-fraunces)]">
+              <BookOpen className="w-5 h-5 text-primary" />
+              Story Preferences
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {/* Tone */}
+            <FormField
+              control={form.control}
+              name="tone"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Story Tone</FormLabel>
+                  <FormControl>
+                    <RadioGroup
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      className="grid grid-cols-1 sm:grid-cols-3 gap-3"
+                    >
+                      {TONES.map((tone) => (
+                        <Label
+                          key={tone.value}
+                          htmlFor={`tone-${tone.value}`}
+                          className={cn(
+                            "flex flex-col items-center gap-2 p-4 rounded-xl border-2 cursor-pointer transition-all",
+                            "hover:border-primary/50 hover:bg-primary/5",
+                            field.value === tone.value
+                              ? "border-primary bg-primary/10"
+                              : "border-input"
+                          )}
+                        >
+                          <RadioGroupItem
+                            id={`tone-${tone.value}`}
+                            value={tone.value}
+                            className="sr-only"
+                          />
+                          <span className="font-medium">{tone.label}</span>
+                          <span className="text-xs text-muted-foreground text-center">
+                            {tone.description}
+                          </span>
+                        </Label>
+                      ))}
+                    </RadioGroup>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Optional Lesson */}
+            <FormField
+              control={form.control}
+              name="lesson"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Special Message{" "}
+                    <span className="text-muted-foreground font-normal">
+                      (optional)
+                    </span>
+                  </FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="e.g., Learning to share with friends, Being brave at the doctor..."
+                      className="resize-none"
+                      maxLength={140}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription className="flex justify-between">
+                    <span>A lesson or theme to weave into the story.</span>
+                    <span className="text-xs tabular-nums">
+                      {field.value?.length || 0}/140
+                    </span>
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+        </Card>
+
+        {/* Section 3: Photo Upload */}
+        <Card className="paper-texture">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 font-[family-name:var(--font-fraunces)]">
+              <Sparkles className="w-5 h-5 text-primary" />
+              Photo Upload
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <FormField
+              control={form.control}
+              name="photo"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="sr-only">Photo</FormLabel>
+                  <FormControl>
+                    <PhotoDropzone
+                      value={field.value ?? null}
+                      onChange={field.onChange}
+                      error={form.formState.errors.photo?.message}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+        </Card>
+
+        {/* Submit Button - Sticky on mobile */}
+        <div className="sticky bottom-4 z-10 sm:static">
+          <Button
+            type="submit"
+            size="lg"
+            disabled={isSubmitting}
+            className="w-full text-base py-6 rounded-full shadow-lg shadow-primary/25 hover:shadow-xl hover:shadow-primary/30 transition-all duration-300"
+          >
+            {isSubmitting ? (
+              <>
+                <Spinner className="mr-2" />
+                Creating Preview...
+              </>
+            ) : (
+              <>
+                <Sparkles className="mr-2 w-5 h-5" />
+                Create Preview
+              </>
+            )}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/components/create/InterestsInput.tsx
+++ b/components/create/InterestsInput.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import * as React from "react";
+import { X, Plus } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { PRESET_INTERESTS } from "@/lib/constants/storyOptions";
+
+interface InterestsInputProps {
+  value: string[];
+  onChange: (value: string[]) => void;
+  maxSelections?: number;
+  error?: boolean;
+}
+
+export function InterestsInput({
+  value,
+  onChange,
+  maxSelections = 3,
+  error = false,
+}: InterestsInputProps) {
+  const [customInput, setCustomInput] = React.useState("");
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const isAtLimit = value.length >= maxSelections;
+  const availablePresets = PRESET_INTERESTS.filter(
+    (interest) => !value.includes(interest)
+  );
+
+  const addInterest = (interest: string) => {
+    const trimmed = interest.trim();
+    if (trimmed && !value.includes(trimmed) && value.length < maxSelections) {
+      onChange([...value, trimmed]);
+    }
+  };
+
+  const removeInterest = (interest: string) => {
+    onChange(value.filter((i) => i !== interest));
+  };
+
+  const handleCustomSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (customInput.trim() && customInput.length <= 30) {
+      addInterest(customInput);
+      setCustomInput("");
+      inputRef.current?.focus();
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleCustomSubmit(e);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Selected interests */}
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {value.map((interest) => (
+            <Badge
+              key={interest}
+              variant="default"
+              className="pl-3 pr-1 py-1.5 gap-1 text-sm"
+            >
+              {interest}
+              <button
+                type="button"
+                onClick={() => removeInterest(interest)}
+                className="ml-1 rounded-full p-0.5 hover:bg-primary-foreground/20 transition-colors"
+                aria-label={`Remove ${interest}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {/* Custom input */}
+      {!isAtLimit && (
+        <div className="flex gap-2">
+          <Input
+            ref={inputRef}
+            type="text"
+            placeholder="Add custom interest..."
+            value={customInput}
+            onChange={(e) => setCustomInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            maxLength={30}
+            className={cn(error && value.length === 0 && "border-destructive")}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            disabled={!customInput.trim()}
+            onClick={handleCustomSubmit}
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      {/* Preset interests */}
+      <div className="space-y-2">
+        <p className="text-sm text-muted-foreground">
+          {isAtLimit
+            ? "Maximum selections reached"
+            : `Or choose from suggestions (${value.length}/${maxSelections})`}
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {availablePresets.map((interest) => (
+            <Badge
+              key={interest}
+              variant="outline"
+              className={cn(
+                "cursor-pointer transition-all hover:bg-primary/10 hover:border-primary/50",
+                isAtLimit &&
+                  "opacity-50 cursor-not-allowed hover:bg-transparent hover:border-input"
+              )}
+              onClick={() => !isAtLimit && addInterest(interest)}
+            >
+              {interest}
+            </Badge>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/create/PhotoDropzone.tsx
+++ b/components/create/PhotoDropzone.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import * as React from "react";
+import { Upload, X, ImageIcon, AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { PHOTO_CONFIG } from "@/lib/constants/storyOptions";
+
+interface PhotoDropzoneProps {
+  value: File | null;
+  onChange: (file: File | null) => void;
+  error?: string;
+}
+
+export function PhotoDropzone({ value, onChange, error }: PhotoDropzoneProps) {
+  const [isDragging, setIsDragging] = React.useState(false);
+  const [preview, setPreview] = React.useState<string | null>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  // Generate preview URL when file changes
+  React.useEffect(() => {
+    if (value) {
+      const url = URL.createObjectURL(value);
+      setPreview(url);
+      return () => URL.revokeObjectURL(url);
+    } else {
+      setPreview(null);
+    }
+  }, [value]);
+
+  const validateAndSetFile = (file: File) => {
+    // Type validation
+    if (
+      !(PHOTO_CONFIG.acceptedTypes as readonly string[]).includes(file.type)
+    ) {
+      return;
+    }
+    // Size validation
+    if (file.size > PHOTO_CONFIG.maxSizeBytes) {
+      return;
+    }
+    onChange(file);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const file = e.dataTransfer.files[0];
+    if (file) {
+      validateAndSetFile(file);
+    }
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      validateAndSetFile(file);
+    }
+    // Reset input so same file can be selected again
+    e.target.value = "";
+  };
+
+  const handleRemove = () => {
+    onChange(null);
+  };
+
+  const handleReplace = () => {
+    inputRef.current?.click();
+  };
+
+  // Render preview state
+  if (preview && value) {
+    return (
+      <div className="space-y-3">
+        <div className="relative rounded-xl overflow-hidden border-2 border-primary/30 bg-card">
+          <img
+            src={preview}
+            alt="Uploaded photo preview"
+            className="w-full h-64 object-cover"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent" />
+          <div className="absolute bottom-0 left-0 right-0 p-4 flex items-center justify-between">
+            <span className="text-white text-sm truncate max-w-[60%]">
+              {value.name}
+            </span>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={handleReplace}
+              >
+                Replace
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                size="icon-sm"
+                onClick={handleRemove}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Use a clear face photo in good light for best results.
+        </p>
+        <input
+          ref={inputRef}
+          type="file"
+          accept={PHOTO_CONFIG.acceptString}
+          onChange={handleFileSelect}
+          className="hidden"
+          aria-hidden="true"
+        />
+      </div>
+    );
+  }
+
+  // Render dropzone state
+  return (
+    <div className="space-y-2">
+      <div
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onClick={() => inputRef.current?.click()}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            inputRef.current?.click();
+          }
+        }}
+        tabIndex={0}
+        role="button"
+        aria-label="Upload photo"
+        className={cn(
+          "relative flex flex-col items-center justify-center gap-4 p-8 border-2 border-dashed rounded-xl cursor-pointer transition-all duration-200",
+          "hover:border-primary/50 hover:bg-primary/5",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          isDragging && "border-primary bg-primary/10",
+          error && "border-destructive bg-destructive/5"
+        )}
+      >
+        <div
+          className={cn(
+            "w-16 h-16 rounded-full flex items-center justify-center",
+            "bg-primary/10 text-primary",
+            isDragging && "bg-primary/20"
+          )}
+        >
+          {isDragging ? (
+            <Upload className="w-8 h-8 animate-bounce" />
+          ) : (
+            <ImageIcon className="w-8 h-8" />
+          )}
+        </div>
+
+        <div className="text-center">
+          <p className="text-sm font-medium">
+            {isDragging ? "Drop your photo here" : "Drag & drop your photo"}
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            or click to browse
+          </p>
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          JPG, PNG, or WebP up to {PHOTO_CONFIG.maxSizeMB}MB
+        </p>
+
+        <input
+          ref={inputRef}
+          type="file"
+          accept={PHOTO_CONFIG.acceptString}
+          onChange={handleFileSelect}
+          className="hidden"
+          aria-hidden="true"
+        />
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 text-destructive text-sm">
+          <AlertCircle className="h-4 w-4 flex-shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/constants/storyOptions.ts
+++ b/lib/constants/storyOptions.ts
@@ -1,0 +1,52 @@
+// Centralized constants for story creation options
+// Single source of truth for form options used across the app
+
+export const AGE_BANDS = [
+  { value: "3-4", label: "3-4 years" },
+  { value: "5-6", label: "5-6 years" },
+  { value: "7-9", label: "7-9 years" },
+] as const;
+
+export const TONES = [
+  {
+    value: "gentle",
+    label: "Gentle",
+    description: "Soft, calming, and soothing",
+  },
+  {
+    value: "funny",
+    label: "Funny",
+    description: "Silly, playful, and giggly",
+  },
+  {
+    value: "brave",
+    label: "Brave",
+    description: "Adventurous and courageous",
+  },
+] as const;
+
+export const PRESET_INTERESTS = [
+  "Dinosaurs",
+  "Space",
+  "Unicorns",
+  "Pirates",
+  "Jungle",
+  "Underwater",
+  "Princess",
+  "Dragons",
+  "Cars",
+  "Animals",
+  "Soccer",
+  "Ballet",
+] as const;
+
+export const PHOTO_CONFIG = {
+  acceptedTypes: ["image/jpeg", "image/jpg", "image/png", "image/webp"],
+  acceptString: ".jpg,.jpeg,.png,.webp",
+  maxSizeBytes: 8 * 1024 * 1024, // 8MB
+  maxSizeMB: 8,
+} as const;
+
+// Type exports for use elsewhere
+export type AgeBand = (typeof AGE_BANDS)[number]["value"];
+export type Tone = (typeof TONES)[number]["value"];

--- a/lib/validators/createBook.ts
+++ b/lib/validators/createBook.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import { PHOTO_CONFIG } from "@/lib/constants/storyOptions";
+
+// Custom file validation for client-side (File object)
+const photoSchema = z
+  .instanceof(File, { message: "Please upload a photo" })
+  .refine(
+    (file) =>
+      (PHOTO_CONFIG.acceptedTypes as readonly string[]).includes(file.type),
+    {
+      message: "Please upload a JPG, PNG, or WebP image",
+    }
+  )
+  .refine((file) => file.size <= PHOTO_CONFIG.maxSizeBytes, {
+    message: `Photo must be smaller than ${PHOTO_CONFIG.maxSizeMB}MB`,
+  });
+
+export const createBookSchema = z.object({
+  // Child Details
+  childName: z
+    .string()
+    .min(2, "Name must be at least 2 characters")
+    .max(32, "Name must be 32 characters or less")
+    .regex(
+      /^[a-zA-Z\s'-]+$/,
+      "Name can only contain letters, spaces, hyphens, and apostrophes"
+    ),
+
+  ageBand: z.enum(["3-4", "5-6", "7-9"], {
+    message: "Please select an age range",
+  }),
+
+  interests: z
+    .array(z.string().min(1).max(30))
+    .min(1, "Please select at least 1 interest")
+    .max(3, "Please select up to 3 interests"),
+
+  // Story Preferences
+  tone: z.enum(["gentle", "funny", "brave"], {
+    message: "Please select a story tone",
+  }),
+
+  lesson: z
+    .string()
+    .max(140, "Lesson must be 140 characters or less")
+    .optional()
+    .or(z.literal("")),
+
+  // Photo
+  photo: photoSchema,
+});
+
+// Infer TypeScript type from schema
+export type CreateBookFormData = z.infer<typeof createBookSchema>;
+
+// Type for sessionStorage (photo stored as dataURL)
+export type CreateBookFormStorage = Omit<CreateBookFormData, "photo"> & {
+  photoDataUrl: string;
+  photoName: string;
+  photoType: string;
+};


### PR DESCRIPTION
## Summary
- Add complete book creation form at `/create` with client-side validation
- Create InterestsInput component (multi-select with preset options + custom entry)
- Create PhotoDropzone component (drag/drop, preview, replace functionality)
- Add Zod validation schema for all form fields
- Add form persistence via sessionStorage (auto-save on change)
- Add sticky submit button on mobile for better UX

## Test plan
- [ ] Navigate to `/create` and verify form renders correctly
- [ ] Test all validation rules (name length, interests 1-3, required fields)
- [ ] Test photo upload via drag/drop and click-to-browse
- [ ] Test photo preview, replace, and remove functionality
- [ ] Verify form data persists on page refresh (except photo)
- [ ] Test mobile layout with sticky submit button
- [ ] Submit valid form and verify redirect to `/create/preview`

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)