### PR TITLE
security: Fix exposed service role key (GitGuardian #9)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.5.6] - 2026-01-09
+
+### Security - Fix Exposed Service Role Key (GitGuardian Alert)
+
+**Issue:** #9 - The Supabase service role JWT was accidentally committed to the repository in migration `20260108_trigger_edge_function.sql`, triggering a GitGuardian alert.
+
+**Root Cause:** The database trigger function for calling the Edge Function had the service role key hardcoded directly in the SQL instead of using secure secret storage.
+
+**Fix:**
+1. Created new migration `20260109_fix_secret_use_vault.sql` that updates the trigger function to read the service role key from Supabase Vault instead of having it hardcoded
+2. Updated the original migration file to remove the exposed secret from the codebase
+
+**Required Actions (Manual):**
+1. **CRITICAL**: Rotate the service role key in Supabase Dashboard:
+   - Go to Settings > API > Service Role Key > Regenerate
+2. Store the new key in Vault by running this SQL in the Supabase SQL Editor:
+   ```sql
+   SELECT vault.create_secret('your-new-service-role-key', 'service_role_key');
+   ```
+
+**Security Best Practice:** Secrets should always be stored in Supabase Vault and accessed via `vault.decrypted_secrets`, never hardcoded in SQL functions or migrations.
+
+---
+
 ## [0.5.5] - 2026-01-08
 
 ### Fixed - Preview API Column Names (Regression Fix)

--- a/supabase/functions/process-book-job/index.ts
+++ b/supabase/functions/process-book-job/index.ts
@@ -2,7 +2,8 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
-const SERVICE_SECRET_KEY = Deno.env.get("SERVICE_SECRET_KEY")!;
+// SUPABASE_SERVICE_ROLE_KEY is automatically provided by Supabase Edge Functions
+const SERVICE_SECRET_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 const OPENROUTER_API_KEY = Deno.env.get("OPENROUTER_API_KEY")!;
 
 // Constants - each image gets its own step to avoid CPU timeout

--- a/supabase/functions/process-book-job/index.ts
+++ b/supabase/functions/process-book-job/index.ts
@@ -2,7 +2,7 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
-const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const SERVICE_SECRET_KEY = Deno.env.get("SERVICE_SECRET_KEY")!;
 const OPENROUTER_API_KEY = Deno.env.get("OPENROUTER_API_KEY")!;
 
 // Constants - each image gets its own step to avoid CPU timeout
@@ -23,7 +23,7 @@ const BOOK_STATUS = {
 
 // Create Supabase admin client
 function createAdminClient() {
-  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  return createClient(SUPABASE_URL, SERVICE_SECRET_KEY, {
     auth: { persistSession: false },
   });
 }
@@ -649,7 +649,7 @@ Deno.serve(async (req: Request) => {
         {
           method: "POST",
           headers: {
-            "Authorization": `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+            "Authorization": `Bearer ${SERVICE_SECRET_KEY}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ job_id: jobId }),

--- a/supabase/migrations/20260109_fix_secret_use_vault.sql
+++ b/supabase/migrations/20260109_fix_secret_use_vault.sql
@@ -1,0 +1,46 @@
+-- Migration: Fix exposed service role key by using Supabase Vault
+--
+-- IMPORTANT: Before running this migration, you MUST:
+-- 1. Rotate your service role key in Supabase Dashboard (Settings > API > Regenerate)
+-- 2. Store the NEW key in Vault by running this SQL in the SQL Editor:
+--    SELECT vault.create_secret('your-new-service-role-key', 'service_role_key');
+--
+-- This migration updates the trigger function to read the service role key from Vault
+-- instead of having it hardcoded in the function body.
+
+-- Update the trigger function to use Vault
+CREATE OR REPLACE FUNCTION trigger_process_book_job()
+RETURNS TRIGGER AS $$
+DECLARE
+  edge_function_url TEXT;
+  service_role_key TEXT;
+BEGIN
+  -- Construct the Edge Function URL
+  edge_function_url := 'https://ywedqotuxqkccplappje.supabase.co/functions/v1/process-book-job';
+
+  -- Get service role key from Vault (secure storage)
+  SELECT decrypted_secret INTO service_role_key
+  FROM vault.decrypted_secrets
+  WHERE name = 'service_role_key';
+
+  -- Check if the secret was found
+  IF service_role_key IS NULL THEN
+    RAISE WARNING 'service_role_key not found in vault. Please run: SELECT vault.create_secret(''your-key'', ''service_role_key'');';
+    RETURN NEW;
+  END IF;
+
+  -- Make async HTTP request to Edge Function
+  PERFORM net.http_post(
+    url := edge_function_url,
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || service_role_key
+    ),
+    body := jsonb_build_object('job_id', NEW.id)
+  );
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Note: The trigger itself doesn't need to be recreated since we're just updating the function


### PR DESCRIPTION
## Summary
- Fixed GitGuardian alert about exposed Supabase service role JWT in migration file
- Database trigger now reads service role key from Supabase Vault instead of hardcoded value
- Edge Function uses auto-provided `SUPABASE_SERVICE_ROLE_KEY` (no custom secret needed)

## Changes
1. **Migration fix**: Updated `20260108_trigger_edge_function.sql` to use Vault
2. **New migration**: `20260109_fix_secret_use_vault.sql` applies the fix to production
3. **Edge Function**: Uses Supabase's auto-provided service role key

## Manual Setup Required
After merging, ensure the Vault secret is set:
```sql
SELECT vault.create_secret('your-service-role-jwt', 'service_role_key');
```

## Test plan
- [x] Created new book (TomTest) - generation completed successfully
- [x] Verified Edge Function receives webhook and processes jobs
- [x] Confirmed book reaches `preview_ready` status

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)